### PR TITLE
fixes issue where multiple requires causes multiple writes

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ var Charm = exports.Charm = function Charm () {
     this.pending = [];
 }
 
-Charm.prototype = new Stream;
+Charm.prototype = Stream.prototype;
 
 Charm.prototype.write = function (buf) {
     var self = this;


### PR DESCRIPTION
I came across an issue while writing a CLI app where `require('charm')(process.stdout)` being called once inside of `app.js` and once inside of `some_module.js` causes duplicate output. This effect is additive for each time the module is required with the same stream.

This pull request fixes this problem by changing `Charm.prototype = new Stream;` to `Charm.prototype = Stream.prototype`.

Here is a snippet that reproduces the described issue:

```` javascript
var charm1 = require('../index')(process.stdout);

charm1.write('from charm1\n\n');

var charm2 = require('../index')(process.stdout);

charm1.write('from charm1\n');
charm2.write('from charm2\n');
````

You will notice that before `charm` is required a second time the text is only printed once, after the second time each message is duplicated.