### PR TITLE
Corrects erase screen and delete char sequences

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ Charm.prototype.erase = function (s) {
         this.write(encode('[1J'));
     }
     else if (s === 'screen') {
-        this.write(encode('[1J'));
+        this.write(encode('[2J'));
     }
     else {
         this.emit('error', new Error('Unknown erase type: ' + s));
@@ -227,7 +227,7 @@ Charm.prototype.delete = function (s, n) {
         this.write(encode('[' + n + 'M'));
     }
     else if (s === 'char') {
-        this.write(encode('[' + n + 'M'));
+        this.write(encode('[' + n + 'X'));
     }
     else {
         this.emit('error', new Error('Unknown delete type: ' + s));


### PR DESCRIPTION
Currently 'screen' and 'end' are sending the same sequence. '2J' seems to be documented as correct for screen.

'line' and 'char' erasing were also the same. The 'nX' sequence is not something I could find official documentation on, but it was mentioned here: http://ah-tty.sourceforge.net/ah-tty_11.html

Tested in fish and bash on my Mac and it seems to do the right thing deleting characters.