### PR TITLE
Add options for setting colors and format

### DIFF
--- a/example/format-color.js
+++ b/example/format-color.js
@@ -1,0 +1,12 @@
+var charm = require('../')(process, {
+  colors: false,
+  format: false
+})
+
+charm
+  .position(0, 0)
+  .background('red')
+  .foreground('white')
+  .write('no format. no colors.')
+  .move(10, 10)
+  .write('by demand.')

--- a/example/format-color.js
+++ b/example/format-color.js
@@ -10,3 +10,6 @@ charm
   .write('no format. no colors.')
   .move(10, 10)
   .write('by demand.')
+
+charm.setColors(true)
+charm.foreground('blue').write('yesh')

--- a/index.js
+++ b/index.js
@@ -8,40 +8,52 @@ var exports = module.exports = function () {
         if (input) throw new Error('multiple inputs specified')
         else input = s
     }
-    
+
     var output = null;
     function setOutput (s) {
         if (output) throw new Error('multiple outputs specified')
         else output = s
     }
-    
+
+    var colors = true;
+    function setColors (s) {
+      colors = s
+    }
+
+    var format = true;
+    function setFormat (s) {
+      format = s
+    }
+
     for (var i = 0; i < arguments.length; i++) {
         var arg = arguments[i];
         if (!arg) continue;
         if (arg.readable) setInput(arg)
         else if (arg.stdin || arg.input) setInput(arg.stdin || arg.input)
-        
+
         if (arg.writable) setOutput(arg)
         else if (arg.stdout || arg.output) setOutput(arg.stdout || arg.output)
-        
+
+        if (arg.colors !== undefined) setColors(arg.colors)
+        if (arg.format !== undefined) setFormat(arg.format)
     }
-    
+
     if (input && typeof input.fd === 'number' && tty.isatty(input.fd)) {
         if (process.stdin.setRawMode) {
             process.stdin.setRawMode(true);
         }
         else tty.setRawMode(true);
     }
-    
-    var charm = new Charm;
+
+    var charm = new Charm(colors, format);
     if (input) {
         input.pipe(charm);
     }
-    
+
     if (output) {
         charm.pipe(output);
     }
-    
+
     charm.once('^C', process.exit);
     charm.once('end', function () {
       if (input) {
@@ -58,9 +70,11 @@ var exports = module.exports = function () {
     return charm;
 };
 
-var Charm = exports.Charm = function Charm () {
+var Charm = exports.Charm = function Charm (colors, format) {
     this.writable = true;
     this.readable = true;
+    this.colors = colors;
+    this.format = format;
     this.pending = [];
 }
 
@@ -68,11 +82,11 @@ Charm.prototype = new Stream;
 
 Charm.prototype.write = function (buf) {
     var self = this;
-    
+
     if (self.pending.length) {
         var codes = extractCodes(buf);
         var matched = false;
-        
+
         for (var i = 0; i < codes.length; i++) {
             for (var j = 0; j < self.pending.length; j++) {
                 var cb = self.pending[j];
@@ -83,17 +97,17 @@ Charm.prototype.write = function (buf) {
                 }
             }
         }
-        
+
         if (matched) return;
     }
-    
+
     if (buf.length === 1) {
         if (buf[0] === 3) self.emit('^C');
         if (buf[0] === 4) self.emit('^D');
     }
-    
+
     self.emit('data', buf);
-    
+
     return self;
 };
 
@@ -110,10 +124,12 @@ Charm.prototype.end = function (buf) {
 Charm.prototype.reset = function (cb) {
     // resets the screen on iTerm, which appears
     // to lack support for the reset character.
-    this.write(encode('[0m'));
-    this.write(encode('[2J'));
+    if (this.format) {
+      this.write(encode('[0m'));
+      this.write(encode('[2J'));
 
-    this.write(encode('c'));
+      this.write(encode('c'));
+    }
     return this;
 };
 
@@ -133,12 +149,17 @@ Charm.prototype.position = function (x, y) {
                 return true;
             }
         });
-        this.write(encode('[6n'));
+
+        if (this.format) {
+          this.write(encode('[6n'));
+        }
     }
     else {
-        this.write(encode(
-            '[' + Math.floor(y) + ';' + Math.floor(x) + 'f'
-        ));
+        if (this.format) {
+          this.write(encode(
+              '[' + Math.floor(y) + ';' + Math.floor(x) + 'f'
+          ));
+        }
     }
     return this;
 };
@@ -146,193 +167,221 @@ Charm.prototype.position = function (x, y) {
 Charm.prototype.move = function (x, y) {
     // set relative coordinates
     var bufs = [];
-    
+
     if (y < 0) this.up(-y)
     else if (y > 0) this.down(y)
-    
+
     if (x > 0) this.right(x)
     else if (x < 0) this.left(-x)
-    
+
     return this;
 };
 
 Charm.prototype.up = function (y) {
-    if (y === undefined) y = 1;
-    this.write(encode('[' + Math.floor(y) + 'A'));
+    if (this.format) {
+      if (y === undefined) y = 1;
+      this.write(encode('[' + Math.floor(y) + 'A'));
+    }
     return this;
 };
 
 Charm.prototype.down = function (y) {
-    if (y === undefined) y = 1;
-    this.write(encode('[' + Math.floor(y) + 'B'));
+    if (this.format) {
+      if (y === undefined) y = 1;
+      this.write(encode('[' + Math.floor(y) + 'B'));
+    }
     return this;
 };
 
 Charm.prototype.right = function (x) {
-    if (x === undefined) x = 1;
-    this.write(encode('[' + Math.floor(x) + 'C'));
+    if (this.format) {
+      if (x === undefined) x = 1;
+      this.write(encode('[' + Math.floor(x) + 'C'));
+    }
     return this;
 };
 
 Charm.prototype.left = function (x) {
-    if (x === undefined) x = 1;
-    this.write(encode('[' + Math.floor(x) + 'D'));
+    if (this.format) {
+      if (x === undefined) x = 1;
+      this.write(encode('[' + Math.floor(x) + 'D'));
+    }
     return this;
 };
 
 Charm.prototype.column = function (x) {
-    this.write(encode('[' + Math.floor(x) + 'G'));
+    if (this.format) {
+      this.write(encode('[' + Math.floor(x) + 'G'));
+    }
     return this;
 };
 
 Charm.prototype.push = function (withAttributes) {
-    this.write(encode(withAttributes ? '7' : '[s'));
+    if (this.format) {
+      this.write(encode(withAttributes ? '7' : '[s'));
+    }
     return this;
 };
 
 Charm.prototype.pop = function (withAttributes) {
-    this.write(encode(withAttributes ? '8' : '[u'));
+    if (this.format) {
+      this.write(encode(withAttributes ? '8' : '[u'));
+    }
     return this;
 };
 
 Charm.prototype.erase = function (s) {
-    if (s === 'end' || s === '$') {
-        this.write(encode('[K'));
-    }
-    else if (s === 'start' || s === '^') {
-        this.write(encode('[1K'));
-    }
-    else if (s === 'line') {
-        this.write(encode('[2K'));
-    }
-    else if (s === 'down') {
-        this.write(encode('[J'));
-    }
-    else if (s === 'up') {
-        this.write(encode('[1J'));
-    }
-    else if (s === 'screen') {
-        this.write(encode('[1J'));
-    }
-    else {
-        this.emit('error', new Error('Unknown erase type: ' + s));
-    }
-    return this;
-};
-
-Charm.prototype.delete = function (s, n) {  
-    n = n || 1
-
-    if (s === 'line') {
-        this.write(encode('[' + n + 'M'));
-    }
-    else if (s === 'char') {
-        this.write(encode('[' + n + 'M'));
-    }
-    else {
-        this.emit('error', new Error('Unknown delete type: ' + s));
+    if (this.format) {
+      if (s === 'end' || s === '$') {
+          this.write(encode('[K'));
+      }
+      else if (s === 'start' || s === '^') {
+          this.write(encode('[1K'));
+      }
+      else if (s === 'line') {
+          this.write(encode('[2K'));
+      }
+      else if (s === 'down') {
+          this.write(encode('[J'));
+      }
+      else if (s === 'up') {
+          this.write(encode('[1J'));
+      }
+      else if (s === 'screen') {
+          this.write(encode('[1J'));
+      }
+      else {
+          this.emit('error', new Error('Unknown erase type: ' + s));
+      }
     }
     return this;
 };
 
-Charm.prototype.insert = function (mode, n) {  
-    n = n || 1
+Charm.prototype.delete = function (s, n) {
+    if (this.format) {
+      n = n || 1
 
-    if(mode === true) {
-        this.write(encode('[4h'));
+      if (s === 'line') {
+          this.write(encode('[' + n + 'M'));
+      }
+      else if (s === 'char') {
+          this.write(encode('[' + n + 'M'));
+      }
+      else {
+          this.emit('error', new Error('Unknown delete type: ' + s));
+      }
     }
-    else if (mode === false) {
-        this.write(encode('[l'));
-    }
-    else if (mode === 'line') {
-        this.write(encode('[' + n + 'L'));
-    }
-    else if (mode === 'char') {
-        this.write(encode('[' + n + '@'));
-    }
-    else {
-        this.emit('error', new Error('Unknown delete type: ' + s));
+    return this;
+};
+
+Charm.prototype.insert = function (mode, n) {
+    if (this.format) {
+      n = n || 1
+
+      if(mode === true) {
+          this.write(encode('[4h'));
+      }
+      else if (mode === false) {
+          this.write(encode('[l'));
+      }
+      else if (mode === 'line') {
+          this.write(encode('[' + n + 'L'));
+      }
+      else if (mode === 'char') {
+          this.write(encode('[' + n + '@'));
+      }
+      else {
+          this.emit('error', new Error('Unknown delete type: ' + s));
+      }
     }
     return this;
 };
 
 
 Charm.prototype.display = function (attr) {
-    var c = {
-        reset : 0,
-        bright : 1,
-        dim : 2,
-        underscore : 4,
-        blink : 5,
-        reverse : 7,
-        hidden : 8
-    }[attr];
-    if (c === undefined) {
-        this.emit('error', new Error('Unknown attribute: ' + attr));
+    if (this.colors) {
+      var c = {
+          reset : 0,
+          bright : 1,
+          dim : 2,
+          underscore : 4,
+          blink : 5,
+          reverse : 7,
+          hidden : 8
+      }[attr];
+      if (c === undefined) {
+          this.emit('error', new Error('Unknown attribute: ' + attr));
+      }
+      this.write(encode('[' + c + 'm'));
     }
-    this.write(encode('[' + c + 'm'));
     return this;
 };
 
 Charm.prototype.foreground = function (color) {
-    if (typeof color === 'number') {
-        if (color < 0 || color >= 256) {
-            this.emit('error', new Error('Color out of range: ' + color));
-        }
-        this.write(encode('[38;5;' + color + 'm'));
-    }
-    else {
-        var c = {
-            black : 30,
-            red : 31,
-            green : 32,
-            yellow : 33,
-            blue : 34,
-            magenta : 35,
-            cyan : 36,
-            white : 37
-        }[color.toLowerCase()];
-        
-        if (!c) this.emit('error', new Error('Unknown color: ' + color));
-        this.write(encode('[' + c + 'm'));
+    if (this.colors) {
+      if (typeof color === 'number') {
+          if (color < 0 || color >= 256) {
+              this.emit('error', new Error('Color out of range: ' + color));
+          }
+          this.write(encode('[38;5;' + color + 'm'));
+      }
+      else {
+          var c = {
+              black : 30,
+              red : 31,
+              green : 32,
+              yellow : 33,
+              blue : 34,
+              magenta : 35,
+              cyan : 36,
+              white : 37
+          }[color.toLowerCase()];
+
+          if (!c) this.emit('error', new Error('Unknown color: ' + color));
+          this.write(encode('[' + c + 'm'));
+      }
     }
     return this;
 };
 
 Charm.prototype.background = function (color) {
-    if (typeof color === 'number') {
-        if (color < 0 || color >= 256) {
-            this.emit('error', new Error('Color out of range: ' + color));
-        }
-        this.write(encode('[48;5;' + color + 'm'));
-    }
-    else {
-        var c = {
-          black : 40,
-          red : 41,
-          green : 42,
-          yellow : 43,
-          blue : 44,
-          magenta : 45,
-          cyan : 46,
-          white : 47
-        }[color.toLowerCase()];
-        
-        if (!c) this.emit('error', new Error('Unknown color: ' + color));
-        this.write(encode('[' + c + 'm'));
+    if (this.colors) {
+      if (typeof color === 'number') {
+          if (color < 0 || color >= 256) {
+              this.emit('error', new Error('Color out of range: ' + color));
+          }
+          this.write(encode('[48;5;' + color + 'm'));
+      }
+      else {
+          var c = {
+            black : 40,
+            red : 41,
+            green : 42,
+            yellow : 43,
+            blue : 44,
+            magenta : 45,
+            cyan : 46,
+            white : 47
+          }[color.toLowerCase()];
+
+          if (!c) this.emit('error', new Error('Unknown color: ' + color));
+          this.write(encode('[' + c + 'm'));
+      }
     }
     return this;
 };
 
 Charm.prototype.cursor = function (visible) {
-    this.write(encode(visible ? '[?25h' : '[?25l'));
+    if (this.format) {
+      this.write(encode(visible ? '[?25h' : '[?25l'));
+    }
     return this;
 };
 
 var extractCodes = exports.extractCodes = function (buf) {
     var codes = [];
     var start = -1;
-    
+
     for (var i = 0; i < buf.length; i++) {
         if (buf[i] === 27) {
             if (start >= 0) codes.push(buf.slice(start, i));
@@ -342,6 +391,6 @@ var extractCodes = exports.extractCodes = function (buf) {
             codes.push(buf.slice(start));
         }
     }
-    
+
     return codes;
 }

--- a/index.js
+++ b/index.js
@@ -133,8 +133,11 @@ Charm.prototype.end = function (buf) {
 Charm.prototype.reset = function (cb) {
     // resets the screen on iTerm, which appears
     // to lack support for the reset character.
-    if (this.format) {
+    if (this.colors) {
       this.write(encode('[0m'));
+    }
+
+    if (this.format) {
       this.write(encode('[2J'));
 
       this.write(encode('c'));

--- a/index.js
+++ b/index.js
@@ -111,6 +111,15 @@ Charm.prototype.write = function (buf) {
     return self;
 };
 
+Charm.prototype.setFormat = function (b) {
+    this.format = b
+    return this
+}
+
+Charm.prototype.setColors = function (b) {
+    this.colors = b
+    return this
+}
 
 Charm.prototype.destroy = function () {
     this.end();


### PR DESCRIPTION
You can pass in an object to set wether colors and/or formatting should be enabled.

```js
var charm = require('charm')(process, {
  colors: false,
  format: false
})
```

you can always set these properties using `setColors` and `setFormat`

```js
charm
  .position(0, 0)
  .foreground('red')
  .write('this is colored and formatted')
  .setFormat(false)
  .column(20)
  .write('not formatted.')
  .setColors(false)
  .background('blue')
  .write('neither.')
```

Formats includes `position`, `move`, `up`, `down`, `left`, `right`, `column`, `push`, `pop`, `erase`, `delete`, `insert`, `cursor`, `reset` (except for `[0m`)

Colors includes `display`, `foreground`, `background`, `reset`.