### PR TITLE
Reset buffer after clear screen

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,12 +108,9 @@ Charm.prototype.end = function (buf) {
 };
 
 Charm.prototype.reset = function (cb) {
-    // resets the screen on iTerm, which appears
-    // to lack support for the reset character.
-    this.write(encode('[0m'));
     this.write(encode('[2J'));
+    this.write(encode('[3J'));
 
-    this.write(encode('c'));
     return this;
 };
 


### PR DESCRIPTION
Tested on `Mac OS X - El Capitan`.

If you just clear the screen you can see it just prints a bunch of new lines, so if you scroll up everything is still visible.

On `iTerm` this will just `clear` without `reset` (unsupported by `iTerm`)

See this link for reference about the escape codes I used:
http://apple.stackexchange.com/questions/31872/how-do-i-reset-the-scrollback-in-the-terminal-via-a-shell-command

Also this wasn't doing anything special:
```JavaScript
// resets the screen on iTerm, which appears
// to lack support for the reset character.
this.write(encode('[0m'));
this.write(encode('[2J'));

// ^ only the '[2J" part was doing something relevant here, and the "c" part was reduntant
// See my code to see what I mean
```