### PR TITLE
Use one underlying stream per Charm instance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var tty = require('tty');
 var encode = require('./lib/encode');
 var Stream = require('stream').Stream;
+var inherits = require('inherits')
+
+inherits(Charm, Stream)
 
 var exports = module.exports = function () {
     var input = null;
@@ -58,13 +61,12 @@ var exports = module.exports = function () {
     return charm;
 };
 
-var Charm = exports.Charm = function Charm () {
+function Charm () {
     this.writable = true;
     this.readable = true;
     this.pending = [];
 }
-
-Charm.prototype = new Stream;
+exports.Charm = Charm
 
 Charm.prototype.write = function (buf) {
     var self = this;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
         "escape",
         "sequence"
     ],
+    "dependencies": {
+      "inherits": "^2.0.1"
+    },
     "author" : {
         "name" : "James Halliday",
         "email" : "mail@substack.net",


### PR DESCRIPTION
Without this, a single shared Stream instance is used across all instances of Charm. This makes strange things happen when you have multiple Charm instances with different outputs.