### PR TITLE
Use the SPDX identifier for The MIT License

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
         "email" : "mail@substack.net",
         "url" : "http://substack.net"
     },
-    "license" : "MIT/X11",
+    "license" : "MIT",
     "engine" : { "node" : ">=0.4" }
 }


### PR DESCRIPTION
This teeny-tiny PR replaces the current `MIT/X11` in `package.json` with just `MIT`. Machines looking for valid SPDX license identifiers can read the latter unambiguously, making for much easier license audit.

I noticed this browsing my list of the npm top 1,000 most-depended-upon packages. Over 90% have machine-readable license metadata!

Thanks, @noffle! Thanks, @substack!